### PR TITLE
feat(backend): Makefile & .env.template QOL changes

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -23,7 +23,7 @@ CONNECTION_STRING="Host=postgres;Username=postgres;Password=postgres;Database=po
 # since we use minio to mock s3. Even if we are in the
 # docker environment, in code we setup a proxy for minio
 # on correct urls.
-AWS_S3_URL="http://localhost:9000"
+AWS_S3_URL="http://localhost:9002"
 
 # Region to use for s3. Locally it can be left as is.
 AWS_REGION="localhost"

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ ifeq ($(CONTAINER_TOOL),auto)
 	override CONTAINER_TOOL = $(shell docker version >/dev/null 2>&1 && echo docker || echo podman)
 endif
 
-# export ANDROID_HOME ?= auto
-# ifeq ($(ANDROID_HOME),auto)
-# 	$(shell echo "Setup ANDROID_HOME env variable")
-# endif
+export ANDROID_HOME ?= auto
+ifeq ($(ANDROID_HOME),auto)
+$(info "INFO: Setup ANDROID_HOME env variable")
+endif
 
 # Conditional assignment of COMPOSE_COMMAND
 export COMPOSE_COMMAND ?= auto
@@ -152,11 +152,11 @@ dotnet-benchmark: ## Shorthand for running dotnet benchmarks
 ##@ Infrastructure actions
 export AWS_ACCESS_KEY ?= auto
 ifeq ($(AWS_ACCESS_KEY),auto)
-	override AWS_ACCESS_KEY = $(shell taplo get -f ~/.aws/credentials 'service-account.aws_access_key_id')
+	override AWS_ACCESS_KEY := $(shell taplo get -f ~/.aws/credentials 'service-account.aws_access_key_id')
 endif
 export AWS_SECRET_KEY ?= auto
 ifeq ($(AWS_SECRET_KEY),auto)
-	override AWS_SECRET_KEY = $(shell taplo get -f ~/.aws/credentials 'service-account.aws_secret_access_key')
+	override AWS_SECRET_KEY := $(shell taplo get -f ~/.aws/credentials 'service-account.aws_secret_access_key')
 endif
 .PHONY: pulumi-up-staging
 pulumi-up-staging: ## Command to deploy the staging infra

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ ifeq ($(CONTAINER_TOOL),auto)
 	override CONTAINER_TOOL = $(shell docker version >/dev/null 2>&1 && echo docker || echo podman)
 endif
 
-export ANDROID_HOME ?= auto
-ifeq ($(ANDROID_HOME),auto)
-	$(shell echo "Setup ANDROID_HOME env variable")
-endif
+# export ANDROID_HOME ?= auto
+# ifeq ($(ANDROID_HOME),auto)
+# 	$(shell echo "Setup ANDROID_HOME env variable")
+# endif
 
 # Conditional assignment of COMPOSE_COMMAND
 export COMPOSE_COMMAND ?= auto


### PR DESCRIPTION
**Description**:

- Makefile was failing to parse due to **shell** command, used **info** instead because it is invokeable during parsing. (if we want to use **shell** it must be in a specific **target**).
- taplo get was being invoked for each target instead of once, changed "=" operator to ":=" operator.
- .env.template S3 default url changed to 9002 to be copy-pasteable and compatible with current docker compose.

**Checklist**:

~- [ ] Unit tests: Have you added or updated unit tests for your changes and do you need to?~
~- [ ] Integration tests: Have you added or updated integration tests and do you need to?~
~- [ ] Bechmarks: Have you added benchmarks and if so did you run them?~
~- [ ] Documentation: Have you update the relevant documentation to reflect the changes?~

**Additional notes**:
Just making the first time experience better.
